### PR TITLE
Add instructions to capture tiny geometry

### DIFF
--- a/pnp/cad/1.1.0/STLs/README.md
+++ b/pnp/cad/1.1.0/STLs/README.md
@@ -16,4 +16,10 @@ All frame parts should be printed with these settings:
 All print files should be oriented with the correct face on the bed.
 `belt-clamp.stl` may require a brim depending on your printer's abilites.
 
+`back-left-leg.stl` and `front-left-leg.stl` are the same file.  You can just choose one and print it twice.  Also you should use the following parameters in Cura slicer ( or the equivalent settings in any slicer ) to make sure you capture the reinforcement geometry inside the motor mounts.
+
+- "Experimental" -> "Minimum Polygon Circumference" to 0.5mm 
+- "Experimental"-> "Maximum Resolution" to 0.1mm 
+- "Experimental" -> "Maximum Travel Resolution" to 0.2mm
+
 Thanks to [gregsaun's cheat-sheet](https://github.com/gregsaun/maker_cheatsheet) for many of the forumlas and methods used!


### PR DESCRIPTION
Add instructions to the Readme to capture the tiny geometry added by Syber to reinforce the motor mounts when slicing them in Cura.   Suggest adding similar instructions for PrusaSlicer and Slic3r.