### PR TITLE
#134 - Fix CI hash insertion to no longer commit the PCB file

### DIFF
--- a/.github/workflows/generate-mobo-pcb-artifacts.yaml
+++ b/.github/workflows/generate-mobo-pcb-artifacts.yaml
@@ -17,7 +17,7 @@ on:
     - '**.kibot.yaml'
 
 jobs:
-  ERC:
+  generate-artifacts:
     runs-on: ubuntu-latest
     container: setsoft/kicad_auto:latest
       
@@ -92,7 +92,8 @@ jobs:
         git add -f pnp/pcb/ringLight/export
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git commit -m "CI: Generate Gerbers and Associated Artifacts" -a | exit 0
+        git status
+        git commit -m "CI: Generate Gerbers and Associated Artifacts" | exit 0
 
     - name: Push changes
       uses: ad-m/github-push-action@master

--- a/pnp/pcb/mobo/mobo.kicad_pcb
+++ b/pnp/pcb/mobo/mobo.kicad_pcb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:95df83dda3f3d9fd77bffb1a92be1bea8756acb8d414947bf955d12f435ded26
+oid sha256:61a5d7d72394ecc3a28a2b4f494738f522dc56768965ddc77a324d81345ec97b
 size 2208111


### PR DESCRIPTION
Fixes #134 

- Adjustment to remove the -a argument from the commit so we're clearly defining what is to be committed instead of committing all files.
- Update to revert mobo to <<hash>> instead of a specific replaced hash

This integration is taking the PCB file and doing a text replace for <<hash>> with -$(git rev-parse --short HEAD).