### PR TITLE
Updates to PCB requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Many boards in the design are also used in a mechanical way, meaning some specif
 
 #### Feeder Indexing Wheel Configuration
 - Board Thickness: 1mm
-- Pad Plating: ENIG
-- Silk/Mask: White/Matte Black
+- Pad Plating: Any
+- Silk/Mask: Any
 
 ### 3D Printing
 During development of the Index, all parts were printed in PLA. A few parts in particular require quite a high strength if being printed. Of course, every printer runs a bit different, and these are just guidelines to illustrate the necessary strength difference between different parts.


### PR DESCRIPTION
Updates to the index wheel requirements based on discussion with Stephen in the index-dev channel on 2021/03/02.

> stephen Today at 3:30 PM
> i would default to the darkest mask you can get! havent personally tested white, but honestly it shouldnt matter. the sensor is never put in front of mask, only copper plating and a slot
> 
> daveismith (he/him) Today at 3:31 PM
> is ENIG still required?
> 
> stephen Today at 3:31 PM
> no, i recently ordered them with leaded HASL and they worked perfectly.
> 
> daveismith (he/him) Today at 3:32 PM
> so basically you expect the only parameter of import at this point is the board thickness?
> 
> stephen Today at 3:33 PM
> as far as i have tested, yes! the only two indexing wheels ive ordered have been matte black/ENIG, and gloss green/HASL, which covers a wide spread of reflectivity and colors.