### PR TITLE
Enable the ERC check in KiBot for four layer boards.

### DIFF
--- a/config-4layer.kibot.yaml
+++ b/config-4layer.kibot.yaml
@@ -33,8 +33,7 @@ variants:
     pre_transform: fix_rotation
 
 preflight:
-  # Disable ERC for now while GPereira updates these items.
-  run_erc: false
+  run_erc: true
   update_xml: true
   # Disable DRC for now while GPereira updates these items.
   run_drc: false


### PR DESCRIPTION
Enables the ERC check of the MOBO using the KiBot ERC functionality. This produces an ERC report as mobo-erc.txt and should fail the artifact generation when building.