### PR TITLE
Glossary initialisation

### DIFF
--- a/doc/content/en/docs/reference/_index.md
+++ b/doc/content/en/docs/reference/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Reference"
+linkTitle: "Reference"
+weight: 3
+description: >-
+     Section containing reference documentation.
+---
+
+## Introduction
+
+This part of the documentation contains some topics such as
+
+* A glossary of key terms
+* How to contribute to the project
+* How to build and work with the documentation

--- a/doc/content/en/docs/reference/glossary/index.md
+++ b/doc/content/en/docs/reference/glossary/index.md
@@ -1,0 +1,16 @@
+---
+title: "Glossary"
+linkTitle: "Glossary"
+weight: 10
+description: >
+  Glossary of key terms to do with index, electronics and the ecosystem around pick and place machines.
+---
+
+## Glossary
+
+* Index: The open source pick and place machine for creating populated circuit boards on a mid-level manufacturing scale.
+* Mid-level manufacturing: A term used to describe the step between small-scale and large-scale manufacturing where the amounts of products you are making doesn't justify going to a contract manufacturer.
+* Pick and place machine: A machine that can programatically place components onto a circuit board in an automated fashion.
+* PNP: Acronym for Pick and Place.
+* PCB: Acronym for Printed Circuit Board.
+* Printed circuit board: A board which uses certain techniques for components to be spaced closer together and more easily manufactured.


### PR DESCRIPTION
Adds initial reference page and glossary page to the documentation with initial definitions to fill in as required.

Would resolve issue #226 if merged.